### PR TITLE
Change PROGRAM_PATH to connect successfully

### DIFF
--- a/1.lesson/counter/client/counter.ts
+++ b/1.lesson/counter/client/counter.ts
@@ -40,7 +40,7 @@ import {
   /**
    * Path to program files
    */
-  const PROGRAM_PATH = path.resolve(__dirname, '../dist/program');
+  const PROGRAM_PATH = path.resolve(__dirname, '../program/dist/program');
 
   /**
    * Path to program shared object file which should be deployed on chain.


### PR DESCRIPTION
## Problem

Assuming that we built `lib.rs` with `cargo build-bpf --manifest-path=Cargo.toml --bpf-out-dir=dist/program`, then
`npm run start` returns:

```
Error: Failed to read program keypair at '[my directory]/summer-school-of-solana-2022/1.lesson/counter/dist/program/counter-keypair.json' due to error: ENOENT: no such file or directory'
[...]
```

## Solution

```ts
const PROGRAM_PATH = path.resolve(__dirname, '../program/dist/program');
```