### PR TITLE
Fix the path of cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,6 @@
 members = [
     "1.lesson/counter/program",
     "2.lesson/hands-on",
-    "3.lesson/program",
+    "3-4.lesson/program",
     "5.lesson/program",
 ]


### PR DESCRIPTION
After renaming the directory from "3.lesson" to "3-4.lesson", we need to
change the path of cargo workspace so that cargo could find and build
the project.